### PR TITLE
fix: agent-friendly CLI output

### DIFF
--- a/cmd/secrets/add.go
+++ b/cmd/secrets/add.go
@@ -43,16 +43,14 @@ var addCmd = &cobra.Command{
 					value = scanner.Text()
 				}
 				if err := scanner.Err(); err != nil {
-					output.Print(output.Error(commandName, fmt.Errorf("failed to read from stdin: %w", err)))
-					return fmt.Errorf("failed to read from stdin: %w", err)
+					return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to read from stdin: %w", err)))
 				}
 			} else {
 				// Interactive prompt
 				fmt.Printf("Enter secret value for '%s': ", name)
 				byteValue, err := term.ReadPassword(int(syscall.Stdin))
 				if err != nil {
-					output.Print(output.Error(commandName, fmt.Errorf("failed to read password: %w", err)))
-					return fmt.Errorf("failed to read password: %w", err)
+					return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to read password: %w", err)))
 				}
 				fmt.Println() // Add newline after hidden input
 				value = string(byteValue)
@@ -61,13 +59,12 @@ var addCmd = &cobra.Command{
 
 		value = strings.TrimSpace(value)
 		if value == "" {
-			output.Print(output.ErrorMsgWithFix(
+			return output.PrintFail(output.ErrorMsgWithFix(
 				commandName,
 				"secret value cannot be empty",
 				"Provide a value via --value, stdin pipe, or interactive prompt",
 				output.ActionHelp("add"),
 			))
-			return fmt.Errorf("secret value cannot be empty")
 		}
 
 		params := daemon.AddParams{
@@ -86,22 +83,18 @@ var addCmd = &cobra.Command{
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return userErr
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
-			output.Print(output.Error(commandName, fmt.Errorf("failed to add secret: %w", err)))
-			return fmt.Errorf("failed to add secret: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to add secret: %w", err)))
 		}
 
 		var result daemon.AddResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return fmt.Errorf("failed to parse response: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return fmt.Errorf("failed to parse result: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		if result.Success {
@@ -120,8 +113,7 @@ var addCmd = &cobra.Command{
 				output.ActionsAfterAdd(name)...,
 			))
 		} else {
-			output.Print(output.ErrorMsg(commandName, result.Message))
-			return fmt.Errorf("failed to add secret: %s", result.Message)
+			return output.PrintFail(output.ErrorMsg(commandName, result.Message))
 		}
 
 		return nil

--- a/cmd/secrets/audit.go
+++ b/cmd/secrets/audit.go
@@ -26,19 +26,16 @@ The response includes suggested filtering actions to help narrow down results.`,
 
 		resp, err := rpcCall(socketPath, daemon.MethodAudit, params)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to fetch audit log: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to fetch audit log: %w", err)))
 		}
 
 		var result daemon.AuditResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		if len(result.Entries) == 0 {

--- a/cmd/secrets/cleanup.go
+++ b/cmd/secrets/cleanup.go
@@ -38,8 +38,7 @@ Examples:
 		// Resolve absolute path
 		absPath, err := filepath.Abs(cleanupPath)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to resolve path: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to resolve path: %w", err)))
 		}
 
 		// Create watcher
@@ -71,8 +70,7 @@ Examples:
 		// One-time check mode
 		wiped, err := w.Check()
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("cleanup failed: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("cleanup failed: %w", err)))
 		}
 
 		// Build response data

--- a/cmd/secrets/delete.go
+++ b/cmd/secrets/delete.go
@@ -28,17 +28,15 @@ var deleteCmd = &cobra.Command{
 		if !deleteForce {
 			confirmed, err := confirmDeleteSecret(name)
 			if err != nil {
-				output.Print(output.Error(commandName, fmt.Errorf("failed to read confirmation: %w", err)))
-				return err
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to read confirmation: %w", err)))
 			}
 			if !confirmed {
-				output.Print(output.ErrorMsgWithFix(
+				return output.PrintFail(output.ErrorMsgWithFix(
 					commandName,
 					"deletion cancelled",
 					"Re-run with --force to skip confirmation",
 					output.ActionHelp("delete"),
 				))
-				return nil
 			}
 		}
 
@@ -51,38 +49,32 @@ var deleteCmd = &cobra.Command{
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return nil
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
 
 			if strings.Contains(strings.ToLower(err.Error()), "secret not found") {
-				output.Print(output.ErrorWithFix(
+				return output.PrintFail(output.ErrorWithFix(
 					commandName,
 					fmt.Errorf("failed to delete secret: %w", err),
 					"Check available secrets: secrets list",
 					output.Action{Command: "secrets list", Description: "List stored secret names"},
 				))
-				return nil
 			}
 
-			output.Print(output.Error(commandName, fmt.Errorf("failed to delete secret: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to delete secret: %w", err)))
 		}
 
 		var result daemon.DeleteResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		if !result.Success {
-			output.Print(output.ErrorMsg(commandName, result.Message))
-			return nil
+			return output.PrintFail(output.ErrorMsg(commandName, result.Message))
 		}
 
 		output.Print(output.Success(

--- a/cmd/secrets/env.go
+++ b/cmd/secrets/env.go
@@ -40,15 +40,13 @@ Examples:
 		// Find project configuration
 		cfg, projectDir, err := project.FindProjectConfig()
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to find project config: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to find project config: %w", err)))
 		}
 
 		// Determine TTL (flag overrides config)
 		ttl, err := parseTTL(cfg, envTTL)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("invalid TTL: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("invalid TTL: %w", err)))
 		}
 
 		// Build env file path (relative to project directory)
@@ -57,7 +55,7 @@ Examples:
 		// Check if env file exists and handle --force
 		if !envForce && !envDryRun {
 			if _, err := os.Stat(envFilePath); err == nil {
-				output.Print(output.ErrorMsg(
+				return output.PrintFail(output.ErrorMsg(
 					commandName,
 					fmt.Sprintf("env file already exists: %s (use --force to overwrite)", envFilePath),
 					output.Action{
@@ -69,22 +67,19 @@ Examples:
 						Command:     fmt.Sprintf("cat %s | grep 'secrets-ttl'", envFilePath),
 					},
 				))
-				return fmt.Errorf("env file exists")
 			}
 		}
 
 		// Get adapter based on source
 		adapter, err := getAdapter(cfg.Source)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to get adapter: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to get adapter: %w", err)))
 		}
 
 		// Pull secrets from source
 		secrets, err := adapter.Pull(cfg.Project, cfg.Scope)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to pull secrets: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to pull secrets: %w", err)))
 		}
 
 		// Check for required vars
@@ -96,8 +91,7 @@ Examples:
 				}
 			}
 			if len(missingVars) > 0 {
-				output.Print(output.Error(commandName, fmt.Errorf("missing required vars: %v", missingVars)))
-				return fmt.Errorf("required vars missing")
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("missing required vars: %v", missingVars)))
 			}
 		}
 
@@ -127,8 +121,7 @@ Examples:
 
 		// Write to env file with TTL
 		if err := envfile.WriteWithTTL(envFilePath, secrets, ttl, cfg.Source); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to write env file: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to write env file: %w", err)))
 		}
 
 		// Success response

--- a/cmd/secrets/exec.go
+++ b/cmd/secrets/exec.go
@@ -40,27 +40,23 @@ Examples:
 		// Find .secrets.json
 		cfg, projectDir, err := project.FindProjectConfig()
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to find project config: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to find project config: %w", err)))
 		}
 
 		// Get adapter for the configured source
 		adapter, err := getAdapter(cfg.Source)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to initialize adapter: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to initialize adapter: %w", err)))
 		}
 
 		// Pull secrets
 		secrets, err := adapter.Pull(cfg.Project, cfg.Scope)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to pull secrets: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to pull secrets: %w", err)))
 		}
 
 		if len(secrets) == 0 {
-			output.Print(output.Error(commandName, fmt.Errorf("no secrets found for project %q in scope %q", cfg.Project, cfg.Scope)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("no secrets found for project %q in scope %q", cfg.Project, cfg.Scope)))
 		}
 
 		// Build environment variables
@@ -77,8 +73,7 @@ Examples:
 		if execTTL != "" {
 			ttl, err := time.ParseDuration(execTTL)
 			if err != nil {
-				output.Print(output.Error(commandName, fmt.Errorf("invalid ttl: %w", err)))
-				return err
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("invalid ttl: %w", err)))
 			}
 			ctx, cancel = context.WithTimeout(context.Background(), ttl)
 		} else {
@@ -100,8 +95,7 @@ Examples:
 
 		// Start subprocess
 		if err := command.Start(); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to start command: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to start command: %w", err)))
 		}
 
 		// Wait for either signal or process completion
@@ -134,8 +128,7 @@ Examples:
 					// Return exit code
 					os.Exit(exitErr.ExitCode())
 				}
-				output.Print(output.Error(commandName, fmt.Errorf("command failed: %w", err)))
-				return err
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("command failed: %w", err)))
 			}
 
 			// Success
@@ -157,8 +150,7 @@ Examples:
 			if command.Process != nil {
 				_ = command.Process.Kill()
 			}
-			output.Print(output.Error(commandName, fmt.Errorf("command exceeded TTL: %s", execTTL)))
-			return fmt.Errorf("timeout")
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("command exceeded TTL: %s", execTTL)))
 		}
 	},
 }

--- a/cmd/secrets/health.go
+++ b/cmd/secrets/health.go
@@ -30,19 +30,16 @@ Examples:
 		const commandName = "secrets health"
 		resp, err := rpcCall(socketPath, daemon.MethodHealth, daemon.HealthParams{})
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to get health report: %w", err)))
-			return fmt.Errorf("failed to get health report: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to get health report: %w", err)))
 		}
 
 		var result daemon.HealthResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return fmt.Errorf("failed to parse response: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return fmt.Errorf("failed to parse result: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		// If warnings-only mode and no warnings, short-circuit

--- a/cmd/secrets/init.go
+++ b/cmd/secrets/init.go
@@ -24,8 +24,7 @@ and sets up the required directory structure.`,
 
 		// Initialize store (creates directories, identity, and empty secrets file)
 		if err := st.Init(); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to initialize: %w", err)))
-			return fmt.Errorf("failed to initialize: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to initialize: %w", err)))
 		}
 
 		output.Print(output.Success(

--- a/cmd/secrets/lease.go
+++ b/cmd/secrets/lease.go
@@ -67,30 +67,25 @@ Examples:
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return nil
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
 			if strings.Contains(strings.ToLower(err.Error()), "secret not found") {
-				output.Print(output.ErrorWithFix(
+				return output.PrintFail(output.ErrorWithFix(
 					commandName,
 					fmt.Errorf("failed to acquire lease: %w", err),
 					"Check available secrets: secrets status",
 				))
-				return nil
 			}
-			output.Print(output.Error(commandName, fmt.Errorf("failed to acquire lease: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to acquire lease: %w", err)))
 		}
 
 		var result daemon.LeaseResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		// Default behavior: output ONLY the secret value (for piping/substitution)

--- a/cmd/secrets/lease_test.go
+++ b/cmd/secrets/lease_test.go
@@ -90,9 +90,8 @@ func TestLeaseRunEDaemonConnectionErrorUsesStandardFix(t *testing.T) {
 	defer restoreJSONFlag()
 
 	out := captureLeaseStdout(t, func() {
-		if err := leaseCmd.RunE(leaseCmd, []string{"github_token"}); err != nil {
-			t.Fatalf("RunE failed: %v", err)
-		}
+		// RunE now returns ExitError for error paths (non-zero exit code).
+		_ = leaseCmd.RunE(leaseCmd, []string{"github_token"})
 	})
 
 	if !strings.Contains(out, `"fix": "Start the daemon: secrets serve \u0026"`) {

--- a/cmd/secrets/list.go
+++ b/cmd/secrets/list.go
@@ -27,22 +27,18 @@ var listCmd = &cobra.Command{
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return nil
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
-			output.Print(output.Error(commandName, fmt.Errorf("failed to list secrets: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to list secrets: %w", err)))
 		}
 
 		var listResult daemon.ListResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &listResult); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		type listedSecret struct {

--- a/cmd/secrets/list_test.go
+++ b/cmd/secrets/list_test.go
@@ -116,9 +116,8 @@ func TestListRunEDaemonConnectionErrorUsesStandardFix(t *testing.T) {
 	defer restore()
 
 	out := captureListStdout(t, func() {
-		if err := listCmd.RunE(listCmd, nil); err != nil {
-			t.Fatalf("RunE failed: %v", err)
-		}
+		// RunE now returns ExitError for error paths (non-zero exit code).
+		_ = listCmd.RunE(listCmd, nil)
 	})
 
 	if !strings.Contains(out, `"fix": "Start the daemon: secrets serve \u0026"`) {

--- a/cmd/secrets/revoke.go
+++ b/cmd/secrets/revoke.go
@@ -27,24 +27,20 @@ Examples:
 			// Trigger killswitch - revoke all
 			resp, err := rpcCall(socketPath, daemon.MethodRevokeAll, daemon.RevokeAllParams{})
 			if err != nil {
-				output.Print(output.Error(commandName, fmt.Errorf("failed to revoke all leases: %w", err)))
-				return nil
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to revoke all leases: %w", err)))
 			}
 
 			var result daemon.RevokeAllResult
 			data, err := json.Marshal(resp.Result)
 			if err != nil {
-				output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-				return nil
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 			}
 			if err := json.Unmarshal(data, &result); err != nil {
-				output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-				return nil
+				return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 			}
 
 			if !result.Success {
-				output.Print(output.ErrorMsg(commandName, result.Message))
-				return nil
+				return output.PrintFail(output.ErrorMsg(commandName, result.Message))
 			}
 
 			killswitchData := map[string]interface{}{
@@ -62,8 +58,7 @@ Examples:
 
 		// Revoke specific lease
 		if len(args) == 0 {
-			output.Print(output.ErrorMsg(commandName, "lease-id required (or use --all for killswitch)", output.ActionHelp("revoke")))
-			return nil
+			return output.PrintFail(output.ErrorMsg(commandName, "lease-id required (or use --all for killswitch)", output.ActionHelp("revoke")))
 		}
 
 		leaseID := args[0]
@@ -73,24 +68,20 @@ Examples:
 
 		resp, err := rpcCall(socketPath, daemon.MethodRevoke, params)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to revoke lease: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to revoke lease: %w", err)))
 		}
 
 		var result daemon.RevokeResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		if !result.Success {
-			output.Print(output.ErrorMsg(commandName, result.Message))
-			return nil
+			return output.PrintFail(output.ErrorMsg(commandName, result.Message))
 		}
 
 		revokeData := map[string]interface{}{

--- a/cmd/secrets/root.go
+++ b/cmd/secrets/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/joelhooks/agent-secrets/internal/output"
@@ -19,8 +20,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "secrets",
-	Short: "Portable credential management for AI agents",
+	Use:           "secrets",
+	Short:         "Portable credential management for AI agents",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	Long: `agent-secrets provides secure, time-bounded credential management with
 audit logging, rotation hooks, and killswitch capabilities for AI agents.`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -117,6 +120,12 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		// Error JSON is already printed by the command's RunE.
+		// SilenceErrors prevents cobra from re-printing it.
+		var exitErr *output.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/secrets/scan.go
+++ b/cmd/secrets/scan.go
@@ -34,8 +34,7 @@ Examples:
 		// Resolve absolute path
 		absPath, err := filepath.Abs(scanPath)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to resolve path: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to resolve path: %w", err)))
 		}
 
 		// Create scanner with default patterns
@@ -45,8 +44,7 @@ Examples:
 		// Run scan
 		result, err := s.Scan(absPath)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("scan failed: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("scan failed: %w", err)))
 		}
 
 		// Format findings for output

--- a/cmd/secrets/serve.go
+++ b/cmd/secrets/serve.go
@@ -29,13 +29,11 @@ Use --background to run as a background process.`,
 		// Create and start daemon
 		d, err := daemon.NewDaemonWithOptions(cfg, skipPermissionCheck)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to create daemon: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to create daemon: %w", err)))
 		}
 
 		if err := d.Start(); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to start daemon: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to start daemon: %w", err)))
 		}
 
 		if background {
@@ -68,8 +66,7 @@ Use --background to run as a background process.`,
 
 		fmt.Println("\nShutting down...")
 		if err := d.Stop(); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("shutdown error: %w", err)))
-			return err
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("shutdown error: %w", err)))
 		}
 
 		output.Print(output.Success(commandName, map[string]interface{}{

--- a/cmd/secrets/status.go
+++ b/cmd/secrets/status.go
@@ -27,22 +27,18 @@ var statusCmd = &cobra.Command{
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return userErr
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
-			output.Print(output.Error(commandName, fmt.Errorf("failed to get status: %w", err)))
-			return fmt.Errorf("failed to get status: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to get status: %w", err)))
 		}
 
 		var result types.DaemonStatus
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return fmt.Errorf("failed to parse response: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return fmt.Errorf("failed to parse result: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		// Build data map for JSON response

--- a/cmd/secrets/update_secret.go
+++ b/cmd/secrets/update_secret.go
@@ -34,19 +34,17 @@ var updateCmd = &cobra.Command{
 		name := args[0]
 		value, err := readSecretInputValue(name, updateSecretValue)
 		if err != nil {
-			output.Print(output.Error(commandName, err))
-			return err
+			return output.PrintFail(output.Error(commandName, err))
 		}
 
 		value = strings.TrimSpace(value)
 		if value == "" {
-			output.Print(output.ErrorMsgWithFix(
+			return output.PrintFail(output.ErrorMsgWithFix(
 				commandName,
 				"secret value cannot be empty",
 				"Provide a value via --value, stdin pipe, or interactive prompt",
 				output.ActionHelp("update"),
 			))
-			return fmt.Errorf("secret value cannot be empty")
 		}
 
 		params := daemon.UpdateParams{
@@ -67,35 +65,29 @@ var updateCmd = &cobra.Command{
 					"Start the daemon: secrets serve &",
 					"secrets --help",
 				).WithContext("Socket path", socketPath)
-				output.Print(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
-				return userErr
+				return output.PrintFail(output.ErrorWithFix(commandName, userErr, "Start the daemon: secrets serve &"))
 			}
 
 			if strings.Contains(strings.ToLower(err.Error()), "secret not found") {
 				fix := fmt.Sprintf("Secret %q does not exist. Add it first: secrets add %s", name, name)
-				output.Print(output.ErrorWithFix(commandName, fmt.Errorf("failed to update secret: %w", err), fix, output.ActionAdd(name)))
-				return nil
+				return output.PrintFail(output.ErrorWithFix(commandName, fmt.Errorf("failed to update secret: %w", err), fix, output.ActionAdd(name)))
 			}
 
-			output.Print(output.Error(commandName, fmt.Errorf("failed to update secret: %w", err), output.ActionAdd(name)))
-			return nil
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to update secret: %w", err), output.ActionAdd(name)))
 		}
 
 		var result daemon.UpdateResult
 		data, err := json.Marshal(resp.Result)
 		if err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
-			return fmt.Errorf("failed to parse response: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse response: %w", err)))
 		}
 		if err := json.Unmarshal(data, &result); err != nil {
-			output.Print(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
-			return fmt.Errorf("failed to parse result: %w", err)
+			return output.PrintFail(output.Error(commandName, fmt.Errorf("failed to parse result: %w", err)))
 		}
 
 		if !result.Success {
 			fix := fmt.Sprintf("Use `secrets add %s --value <value>` to create it first.", name)
-			output.Print(output.ErrorMsgWithFix(commandName, result.Message, fix, output.ActionAdd(name)))
-			return nil
+			return output.PrintFail(output.ErrorMsgWithFix(commandName, result.Message, fix, output.ActionAdd(name)))
 		}
 
 		output.Print(output.Success(

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -137,6 +137,27 @@ func ErrorMsgWithCode(command, msg string, exitCode int, actions ...Action) Resp
 	}
 }
 
+// ExitError is returned from RunE to signal a non-zero exit code.
+// SilenceErrors prevents cobra from printing it; the JSON was already emitted by Print.
+type ExitError struct {
+	Code int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("exit code %d", e.Code)
+}
+
+// PrintFail prints the error response JSON and returns an ExitError for cobra.
+// Use as: return output.PrintFail(output.Error(cmd, err, actions...))
+func PrintFail(r Response) error {
+	Print(r)
+	code := r.ExitCode
+	if code == 0 {
+		code = types.ExitGenericError
+	}
+	return &ExitError{Code: code}
+}
+
 // Fatal prints an error response and exits with the appropriate exit code.
 func Fatal(r Response) {
 	Print(r)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -248,6 +248,10 @@ func DoUpdate(currentVersion string) error {
 	return nil
 }
 
+// httpClient is a shared HTTP client with a reasonable timeout.
+// Prevents hangs when the GitHub API is slow or unreachable.
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
 func getLatestRelease() (*ReleaseInfo, error) {
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
@@ -257,7 +261,7 @@ func getLatestRelease() (*ReleaseInfo, error) {
 	// Set User-Agent to avoid rate limiting
 	req.Header.Set("User-Agent", fmt.Sprintf("%s-cli", repoName))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -275,8 +279,11 @@ func getLatestRelease() (*ReleaseInfo, error) {
 	return &release, nil
 }
 
+// downloadClient uses a longer timeout for binary downloads.
+var downloadClient = &http.Client{Timeout: 60 * time.Second}
+
 func downloadBinary(url string) (string, error) {
-	resp, err := http.Get(url)
+	resp, err := downloadClient.Get(url)
 	if err != nil {
 		return "", err
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -330,10 +330,20 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 func installMockHTTPClient(t *testing.T, rt roundTripFunc) {
 	t.Helper()
 
+	mockClient := &http.Client{Transport: rt}
+
 	prev := http.DefaultClient
-	http.DefaultClient = &http.Client{Transport: rt}
+	prevHTTP := httpClient
+	prevDL := downloadClient
+
+	http.DefaultClient = mockClient
+	httpClient = mockClient
+	downloadClient = mockClient
+
 	t.Cleanup(func() {
 		http.DefaultClient = prev
+		httpClient = prevHTTP
+		downloadClient = prevDL
 	})
 }
 


### PR DESCRIPTION
- SilenceErrors + SilenceUsage: no more stderr spew alongside JSON
- Non-zero exit codes on all error paths via output.PrintFail()
- HTTP timeout (5s) on update checker to prevent hangs
- Tests updated for new error return pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error message handling and exit code reporting across secret management commands
  * Added timeout protection for update operations to prevent indefinite hangs
  * Improved consistency of error handling behavior for failed operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->